### PR TITLE
Add IntelliJ-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.settings
+.idea
+*.iml


### PR DESCRIPTION
Leaving Eclipse-generated files (.project, .classpath) since these just redirect to maven for dependency handling
which may be useful to people